### PR TITLE
Match room events broadcasting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-   - 2.12.3
+   - 2.12.4
 jdk:
   - oraclejdk8
 

--- a/app/com/codelab27/cards9/binders/Cards9Binders.scala
+++ b/app/com/codelab27/cards9/binders/Cards9Binders.scala
@@ -2,7 +2,7 @@ package com.codelab27.cards9.binders
 
 import com.codelab27.cards9.models.common.Common.Color
 import com.codelab27.cards9.models.matches.Match
-import com.codelab27.cards9.models.matches.Match.{MatchState, PlayerAction}
+import com.codelab27.cards9.models.matches.Match.MatchState
 import com.codelab27.cards9.models.players.Player
 
 import enumeratum._
@@ -36,8 +36,6 @@ object Cards9Binders {
   }
 
   val pbMatchState = EnumPathBindable[MatchState]
-
-  val pbePlayerAction = new PathBindableExtractor[PlayerAction]()(EnumPathBindable[PlayerAction])
 
   val pbeMatchId = new PathBindableExtractor[Match.Id]()(ValueClassPathBindable(Match.Id.unapply, Match.Id.apply))
 

--- a/app/com/codelab27/cards9/controllers/MatchMakerController.scala
+++ b/app/com/codelab27/cards9/controllers/MatchMakerController.scala
@@ -2,11 +2,13 @@ package com.codelab27.cards9.controllers
 
 import com.codelab27.cards9.game.engines
 import com.codelab27.cards9.models.common.Common.Color
-import com.codelab27.cards9.models.matches.Match
 import com.codelab27.cards9.models.matches.Match._
+import com.codelab27.cards9.models.matches.{Match, MatchRoomEvent}
 import com.codelab27.cards9.models.players.Player
 import com.codelab27.cards9.repos.matches.MatchRepository
 
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import io.kanaka.monadic.dsl._
 
 import cats.Bimonad
@@ -14,14 +16,14 @@ import cats.arrow.FunctionK
 import cats.data.OptionT
 
 import play.api.libs.json.Json
-import play.api.mvc.{AbstractController, ControllerComponents}
+import play.api.mvc.{AbstractController, ControllerComponents, WebSocket}
 
 import scala.concurrent.Future
 
 class MatchMakerController[F[_] : Bimonad](
     cc: ControllerComponents,
     matchRepo: MatchRepository[F]
-)(implicit fshandler: FunctionK[F, Future]) extends AbstractController(cc) {
+)(implicit fshandler: FunctionK[F, Future], materializer: Materializer) extends AbstractController(cc) {
 
   implicit val ec = cc.executionContext
 
@@ -30,6 +32,15 @@ class MatchMakerController[F[_] : Bimonad](
 
   import cats.syntax.comonad._
   import cats.syntax.functor._
+
+  val bufferSize = 100
+
+  val overflowStrategy = akka.stream.OverflowStrategy.dropHead
+
+  val (roomEventsQueue, roomEventsPub) = Source.queue[MatchRoomEvent](bufferSize, overflowStrategy)
+    .toMat(Sink.asPublisher(true))(Keep.both).run()
+
+  val roomEventsFlow = Flow.fromSinkAndSource(Sink.ignore, Source.fromPublisher(roomEventsPub))
 
   private def playingOrWaitingMatches(playerId: Player.Id): F[Seq[Match]] = for {
     foundMatches <- matchRepo.findMatchesForPlayer(playerId)
@@ -41,6 +52,7 @@ class MatchMakerController[F[_] : Bimonad](
 
     for {
       matchId <- OptionT(matchRepo.storeMatch(engines.matches.freshMatch)).step ?| (_ => Conflict("Could not create a new match"))
+      _       <- roomEventsQueue.offer(MatchRoomEvent.MatchCreated(matchId))    ?| (_ => Conflict(s"Cannot publish event ${event} to room"))
     } yield {
       Ok(Json.toJson(matchId))
     }
@@ -69,13 +81,14 @@ class MatchMakerController[F[_] : Bimonad](
 
   }
 
-  private def updateMatch(id: Match.Id)(performUpdate: Match => Option[Match]) = {
+  private def updateMatch(id: Match.Id, event: MatchRoomEvent)(performUpdate: Match => Option[Match]) = {
     Action.async { implicit request =>
 
       for {
         theMatch      <- OptionT(matchRepo.findMatch(id)).step            ?| (_ => NotFound(s"Match with identifier ${id.value} not found"))
         updatedMatch  <- OptionT.fromOption(performUpdate(theMatch)).step ?| (_ => Conflict(s"Could not perform action on match ${id.value}"))
         _             <- OptionT(matchRepo.storeMatch(updatedMatch)).step ?| (_ => Conflict(s"Could not update the match"))
+        _             <- roomEventsQueue.offer(event)                     ?| (_ => Conflict(s"Cannot publish event ${event} to room"))
       } yield {
         Ok(Json.toJson(updatedMatch))
       }
@@ -84,15 +97,25 @@ class MatchMakerController[F[_] : Bimonad](
   }
 
   def addPlayer(id: Match.Id, color: Color, playerId: Player.Id) = {
-    updateMatch(id)(theMatch => engines.matches.addPlayerToMatch(theMatch, color, playerId))
+    val event = MatchRoomEvent.PlayerJoin(id, color, playerId)
+
+    updateMatch(id, event)(theMatch => engines.matches.addPlayerToMatch(theMatch, color, playerId))
   }
 
   def removePlayer(id: Match.Id, color: Color) = {
-    updateMatch(id)(theMatch => engines.matches.removePlayerFromMatch(theMatch, color))
+    val event = MatchRoomEvent.PlayerLeave(id, color)
+
+    updateMatch(id, event)(theMatch => engines.matches.removePlayerFromMatch(theMatch, color))
   }
 
   def setReadiness(id: Match.Id, color: Color, isReady: IsReady) = {
-    updateMatch(id)(theMatch => engines.matches.switchPlayerReadiness(theMatch, color, isReady))
+    val event = MatchRoomEvent.PlayerIsReady(id, color, isReady)
+
+    updateMatch(id, event)(theMatch => engines.matches.switchPlayerReadiness(theMatch, color, isReady))
   }
+
+  private def roomEventsTransformer = WebSocket.MessageFlowTransformer.jsonMessageFlowTransformer[String, MatchRoomEvent]
+
+  def subscribeRoomEvents = WebSocket.accept(_ => roomEventsFlow)(roomEventsTransformer)
 
 }

--- a/app/com/codelab27/cards9/controllers/MatchMakerController.scala
+++ b/app/com/codelab27/cards9/controllers/MatchMakerController.scala
@@ -52,7 +52,7 @@ class MatchMakerController[F[_] : Bimonad](
 
     for {
       matchId <- OptionT(matchRepo.storeMatch(engines.matches.freshMatch)).step ?| (_ => Conflict("Could not create a new match"))
-      _       <- roomEventsQueue.offer(MatchRoomEvent.MatchCreated(matchId))    ?| (_ => Conflict(s"Cannot publish event ${event} to room"))
+      _       <- roomEventsQueue.offer(MatchRoomEvent.MatchCreated(matchId))    ?| (_ => Conflict(s"Cannot publish event match creation to room"))
     } yield {
       Ok(Json.toJson(matchId))
     }

--- a/app/com/codelab27/cards9/models/matches/Match.scala
+++ b/app/com/codelab27/cards9/models/matches/Match.scala
@@ -69,20 +69,4 @@ object Match {
 
   }
 
-  sealed trait PlayerAction extends EnumEntry
-
-  object PlayerAction extends Enum[PlayerAction] {
-
-    val values = findValues
-
-    case object Join extends PlayerAction
-
-    case object Leave extends PlayerAction
-
-    case object Ready extends PlayerAction
-
-    case object Start extends PlayerAction
-
-  }
-
 }

--- a/app/com/codelab27/cards9/models/matches/MatchRoomEvent.scala
+++ b/app/com/codelab27/cards9/models/matches/MatchRoomEvent.scala
@@ -6,20 +6,20 @@ import com.codelab27.cards9.models.players.Player
 
 import enumeratum.{Enum, EnumEntry}
 
-sealed trait MatchRoomEvent extends EnumEntry
+sealed abstract class MatchRoomEvent(val discriminator: String) extends EnumEntry
 
 object MatchRoomEvent extends Enum[MatchRoomEvent] {
 
   val values = findValues
 
-  case class MatchCreated(matchId: Match.Id) extends MatchRoomEvent
+  case class MatchCreated(matchId: Match.Id) extends MatchRoomEvent("created")
 
-  case class MatchFinished(matchId: Match.Id) extends MatchRoomEvent
+  case class MatchFinished(matchId: Match.Id) extends MatchRoomEvent("finished")
 
-  case class PlayerJoin(matchId: Match.Id, color: Color, playerId: Player.Id) extends MatchRoomEvent
+  case class PlayerJoin(matchId: Match.Id, color: Color, playerId: Player.Id) extends MatchRoomEvent("join")
 
-  case class PlayerLeave(matchId: Match.Id, color: Color) extends MatchRoomEvent
+  case class PlayerLeave(matchId: Match.Id, color: Color) extends MatchRoomEvent("leave")
 
-  case class PlayerIsReady(matchId: Match.Id, color: Color, isReady: IsReady) extends MatchRoomEvent
+  case class PlayerIsReady(matchId: Match.Id, color: Color, isReady: IsReady) extends MatchRoomEvent("ready")
 
 }

--- a/app/com/codelab27/cards9/models/matches/MatchRoomEvent.scala
+++ b/app/com/codelab27/cards9/models/matches/MatchRoomEvent.scala
@@ -1,0 +1,25 @@
+package com.codelab27.cards9.models.matches
+
+import com.codelab27.cards9.models.common.Common.Color
+import com.codelab27.cards9.models.matches.Match.IsReady
+import com.codelab27.cards9.models.players.Player
+
+import enumeratum.{Enum, EnumEntry}
+
+sealed trait MatchRoomEvent extends EnumEntry
+
+object MatchRoomEvent extends Enum[MatchRoomEvent] {
+
+  val values = findValues
+
+  case class MatchCreated(matchId: Match.Id) extends MatchRoomEvent
+
+  case class MatchFinished(matchId: Match.Id) extends MatchRoomEvent
+
+  case class PlayerJoin(matchId: Match.Id, color: Color, playerId: Player.Id) extends MatchRoomEvent
+
+  case class PlayerLeave(matchId: Match.Id, color: Color) extends MatchRoomEvent
+
+  case class PlayerIsReady(matchId: Match.Id, color: Color, isReady: IsReady) extends MatchRoomEvent
+
+}

--- a/app/com/codelab27/cards9/routes/GameRouter.scala
+++ b/app/com/codelab27/cards9/routes/GameRouter.scala
@@ -18,6 +18,11 @@ class GameRouter[MM[_]](
       matchMakerController.createMatch()
     }
 
+    // Retrieves a websocket that will broadcast every event into the room
+    case GET(p"/matches/room")                                                                   => {
+      matchMakerController.subscribeRoomEvents
+    }
+
     // Match retrieval
     case GET(p"/matches/${pbeMatchId(id)}")                                                      => {
         matchMakerController.retrieveMatch(id)

--- a/app/com/codelab27/cards9/serdes/json/DefaultFormats.scala
+++ b/app/com/codelab27/cards9/serdes/json/DefaultFormats.scala
@@ -5,7 +5,8 @@ import com.codelab27.cards9.models.boards._
 import com.codelab27.cards9.models.cards._
 import com.codelab27.cards9.models.common.Common.Color
 import com.codelab27.cards9.models.matches.Match.{BluePlayer, MatchState, RedPlayer}
-import com.codelab27.cards9.models.matches.{Match, MatchSnapshot}
+import com.codelab27.cards9.models.matches.MatchRoomEvent._
+import com.codelab27.cards9.models.matches.{Match, MatchRoomEvent, MatchSnapshot}
 import com.codelab27.cards9.models.players.Player
 
 import enumeratum._
@@ -110,6 +111,24 @@ object DefaultFormats {
       case Free         => JsString(Free.toString)
     }
   )
+
+  implicit val matchCreatedWrites = Json.writes[MatchCreated]
+
+  implicit val matchFinishedWrites = Json.writes[MatchFinished]
+
+  implicit val playerJoinedWrites = Json.writes[PlayerJoin]
+
+  implicit val playerLeaveWrites = Json.writes[PlayerLeave]
+
+  implicit val playerIsReady = Json.writes[PlayerIsReady]
+
+  implicit val matchRoomEventWrites = Writes[MatchRoomEvent] {
+    case mc: MatchCreated   => matchCreatedWrites.writes(mc)
+    case mf: MatchFinished  => matchFinishedWrites.writes(mf)
+    case pj: PlayerJoin     => playerJoinedWrites.writes(pj)
+    case pl: PlayerLeave    => playerLeaveWrites.writes(pl)
+    case pr: PlayerIsReady  => playerIsReady.writes(pr)
+  }
 
   implicit val boardFormat = Json.format[Board]
 

--- a/app/com/codelab27/cards9/serdes/json/DefaultFormats.scala
+++ b/app/com/codelab27/cards9/serdes/json/DefaultFormats.scala
@@ -122,12 +122,18 @@ object DefaultFormats {
 
   implicit val playerIsReady = Json.writes[PlayerIsReady]
 
-  implicit val matchRoomEventWrites = Writes[MatchRoomEvent] {
-    case mc: MatchCreated   => matchCreatedWrites.writes(mc)
-    case mf: MatchFinished  => matchFinishedWrites.writes(mf)
-    case pj: PlayerJoin     => playerJoinedWrites.writes(pj)
-    case pl: PlayerLeave    => playerLeaveWrites.writes(pl)
-    case pr: PlayerIsReady  => playerIsReady.writes(pr)
+  implicit val matchRoomEventWrites = Writes[MatchRoomEvent] { event =>
+    val discriminator = event.discriminator
+
+    val jsonEvent = event match {
+      case mc: MatchCreated  => matchCreatedWrites.writes(mc)
+      case mf: MatchFinished => matchFinishedWrites.writes(mf)
+      case pj: PlayerJoin    => playerJoinedWrites.writes(pj)
+      case pl: PlayerLeave   => playerLeaveWrites.writes(pl)
+      case pr: PlayerIsReady => playerIsReady.writes(pr)
+    }
+
+    jsonEvent + ("discriminator" -> Json.toJson(discriminator))
   }
 
   implicit val boardFormat = Json.format[Board]


### PR DESCRIPTION
This resolves #10 with a very basic broadcasting mechanism based on a publisher-only Akka Flow and Play websockets, discarding any input from outside, making it read-only. Any action like `PUT`ing a player into a match will be pushed to the subscribers.

Frontend will need to deal with websockets timeouts, as Play only maintains their connections for a limited time if they are not used.